### PR TITLE
Fix writing graph to the file

### DIFF
--- a/pyrates/utility/visualization.py
+++ b/pyrates/utility/visualization.py
@@ -625,7 +625,7 @@ def plot_network_graph(circuit, _format: str = "png", path: str = None, prog="do
 
     # check and format given path
     if path:
-        return write_graph(path, dot_graph, prog, **pydot_args)
+        return write_graph(path, dot_graph, _format, prog, **pydot_args)
 
     else:
         return show_graph(dot_graph, _format, prog, **pydot_args)
@@ -686,19 +686,20 @@ def plot_graph_with_subgraphs(circuit, _format: str = "png", path: str = None, p
     #
     # # check and format given path
     if path:
-        return write_graph(path, graph, prog, **pydot_args)
+        return write_graph(path, graph, _format, prog, **pydot_args)
 
     else:
         return show_graph(graph, _format, prog, **pydot_args)
 
 
-def write_graph(path, dot_graph, prog, **pydot_args):
+def write_graph(path, dot_graph, _format, prog, **pydot_args):
     """Write DOT graph to file.
 
     Parameters
     ----------
     path
     dot_graph
+    _format
     prog
     pydot_args
 
@@ -710,7 +711,7 @@ def write_graph(path, dot_graph, prog, **pydot_args):
     path = os.path.normpath(path)
 
     # draw graph and write to file, given the format
-    return dot_graph.write(path, format=format, prog=prog, **pydot_args)
+    return dot_graph.write(path, format=_format, prog=prog, **pydot_args)
 
 
 def show_graph(dot_graph, _format, prog, **pydot_args):


### PR DESCRIPTION
The writing network graph to the file does not work with the following error:
```
"dot" with args ['-T<built-in function format>', '/var/folders/2q/q8mj2sqx5yj82b2t14j14rq40000gn/T/tmpecd9dl1x'] returned code: 1

stdout, stderr:
 b''
b'Format: "<built-in function format>" not recognized. Use one of: bmp canon cgimage cmap cmapx cmapx_np dot dot_json eps exr fig gd gd2 gif gv icns ico imap imap_np ismap jp2 jpe jpeg jpg json json0 mp pct pdf pic pict plain plain-ext png pov ps ps2 psd sgi svg svgz tga tif tiff tk vml vmlz vrml wbmp xdot xdot1.2 xdot1.4 xdot_json\n'

Traceback (most recent call last):
  File "20190925-pyrates_JRC_test/simulation.py", line 30, in <module>
    main()
  File "20190925-pyrates_JRC_test/simulation.py", line 26, in main
    jrc.describe()
  File "/Users/nikola/work-brain/sleep_rhythms/code/pyrates_helper.py", line 152, in describe
    path=os.path.join(self.results_folder, "network_graph.png"),
  File "/Users/nikola/.virtualenvs/sleepy3/lib/python3.7/site-packages/pyrates/utility/visualization.py", line 628, in plot_network_graph
    return write_graph(path, dot_graph, prog, **pydot_args)
  File "/Users/nikola/.virtualenvs/sleepy3/lib/python3.7/site-packages/pyrates/utility/visualization.py", line 713, in write_graph
    return dot_graph.write(path, format=format, prog=prog, **pydot_args)
  File "/Users/nikola/.virtualenvs/sleepy3/lib/python3.7/site-packages/pydot.py", line 1817, in write
    s = self.create(prog, format, encoding=encoding)
  File "/Users/nikola/.virtualenvs/sleepy3/lib/python3.7/site-packages/pydot.py", line 1945, in create
    assert process.returncode == 0, process.returncode
AssertionError: 1
```

This simple fix passes `_format` keyword to the `pydot`'s `write` function.