### PR TITLE
Initialise CircuitTemplate with correct edge templates

### DIFF
--- a/pyrates/frontend/template/circuit/circuit.py
+++ b/pyrates/frontend/template/circuit/circuit.py
@@ -173,12 +173,17 @@ class CircuitTemplate(AbstractBaseTemplate):
         for edge in edges:
             if isinstance(edge, dict):
                 edge = (edge["source"], edge["target"], edge["template"], edge["variables"])
-            path = edge[2]
-            try:
-                path = self._complete_template_path(path, self.path)
-                temp = EdgeTemplate.from_yaml(path)
-            except TypeError:
-                temp = None
+            # "template" is EdgeTemplate, just use it
+            if isinstance(edge[2], EdgeTemplate):
+                temp = edge[2]
+            # if not, try to load template path from yaml
+            else:
+                path = edge[2]
+                try:
+                    path = self._complete_template_path(path, self.path)
+                    temp = EdgeTemplate.from_yaml(path)
+                except TypeError:
+                    temp = None
             edges_with_templates.append((*edge[0:2], temp, *edge[3:]))
         return edges_with_templates
 


### PR DESCRIPTION
The code in `CircuitTemplate` when initializing edges supposes that the template passed in edge definition is a path to the edge template, not `EdgeTemplate` itself. When you pass edge like
```python
["source", "target", edge_template, {"weight": 1., delay: 0.001}]
```
with edge_template being the instance of `EdgeTemplate`, the `CircuitTemplate` code tries to find appropriate yaml file and if not found (which is the case), it just inserts `None` as the edge template.

This simple fix checks whether the passed template is already an `EdgeTemplate` and if so, just passes it forward.