### PR TITLE
Fix for travis

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,13 @@
 """Pytest module-wide configuration file."""
 
 import pytest
+import os
+
+
+@pytest.fixture(scope="session")
+def ensure_test_directory():
+    if os.getcwd().endswith("PyRates"):
+        os.chdir("tests/")
 
 
 @pytest.fixture(autouse=True)
@@ -9,9 +16,6 @@ def run_around_tests():
     # Find and save current (test) working directory
     import os
     import warnings
-    cwd = os.getcwd()
-    if not cwd.endswith("tests"):
-        os.chdir("tests/")
     cwd = os.getcwd()
     warnings.warn(f"before: {cwd}")
     # A test function will be run at this point

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ def run_around_tests():
     import os
     import warnings
     cwd = os.getcwd()
+    if not cwd.endswith("tests"):
+        os.chdir("tests/")
+    cwd = os.getcwd()
     warnings.warn(f"before: {cwd}")
     # A test function will be run at this point
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,17 @@
 
 import pytest
 
+
 @pytest.fixture(autouse=True)
 def run_around_tests():
     # Code that will run before your test
     # Find and save current (test) working directory
     import os
     cwd = os.getcwd()
+    print(f"before: {cwd}")
     # A test function will be run at this point
     yield
     # Code that will run after the test
+    print(f"after: {os.getcwd()}")
     # revert changes to working directory
     os.chdir(cwd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,12 @@ def run_around_tests():
     # Code that will run before your test
     # Find and save current (test) working directory
     import os
+    import warnings
     cwd = os.getcwd()
-    print(f"before: {cwd}")
+    warnings.warn(f"before: {cwd}")
     # A test function will be run at this point
     yield
     # Code that will run after the test
-    print(f"after: {os.getcwd()}")
+    warnings.warn(f"\n after: {os.getcwd()}")
     # revert changes to working directory
     os.chdir(cwd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,13 +14,9 @@ def ensure_test_directory():
 def run_around_tests():
     # Code that will run before your test
     # Find and save current (test) working directory
-    import os
-    import warnings
     cwd = os.getcwd()
-    warnings.warn(f"before: {cwd}")
     # A test function will be run at this point
     yield
     # Code that will run after the test
-    warnings.warn(f"\n after: {os.getcwd()}")
     # revert changes to working directory
     os.chdir(cwd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 import os
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def ensure_test_directory():
     if os.getcwd().endswith("PyRates"):
         os.chdir("tests/")

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -52,10 +52,18 @@ def test_pickle_template():
     # pickle.dump(template, open("resources/jansen_rit_template.p", "wb"), protocol=pickle.HIGHEST_PROTOCOL)
     pickle.dump(template, out_file)
 
-    if os.path.getsize(out_file) == os.path.getsize(test_file):
-        assert filecmp.cmp(out_file, test_file, shallow=False)
-    else:
-        raise ValueError("File are not the same")
+    try:
+        if os.path.getsize(out_file) == os.path.getsize(test_file):
+            assert filecmp.cmp(out_file, test_file, shallow=False)
+        else:
+            raise ValueError("Files are not the same")
+    except FileNotFoundError as e:
+        for path, dirs, files in os.walk(os.getcwd()):
+            print(path)
+            for f in files:
+                print(f)
+
+        raise FileNotFoundError(f"Files: {out_file}, {test_file}, CWD: {os.getcwd()}, ")
 
     data = pickle.load(out_file)
     assert data

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -58,10 +58,6 @@ def test_pickle_template():
         else:
             raise ValueError("Files are not the same")
     except FileNotFoundError as e:
-        for path, dirs, files in os.walk(os.getcwd()):
-            print(path)
-            for f in files:
-                print(f)
 
         raise FileNotFoundError(f"Files: {out_file}, {test_file}, CWD: {os.getcwd()}, ")
 

--- a/tests/test_frontend_yaml_parser.py
+++ b/tests/test_frontend_yaml_parser.py
@@ -190,3 +190,5 @@ def test_yaml_dump():
     # reload saved circuit
     saved_circuit = CircuitTemplate.from_yaml("output/yaml_dump/DumpedCircuit").apply()
     assert saved_circuit
+
+    # ToDo: figure out a simple way to compare both instances


### PR DESCRIPTION
travis starts tests in the base environment instead of in the tests/ folder. Fixed that by setting up a fixture that sets and recovers the correct directory. 