### PR TITLE
Try fixing issue #39, also a typo in python_definitions.py

### DIFF
--- a/documentation/model_implementation/python_definitions.py
+++ b/documentation/model_implementation/python_definitions.py
@@ -63,7 +63,7 @@ from pyrates.frontend import OperatorTemplate
 
 pro = OperatorTemplate(
     name='PRO', path=None,
-    equations=["m_out = 2.*m_max / (1 + exp(r*(V_th - V)))"],
+    equations=["m_out = 2.*m_max / (1 + exp(r*(V_thr - V)))"],
     variables={'m_out': 'output',
                'V': 'input',
                'V_thr': 6e-3,

--- a/pyrates/frontend/template/circuit.py
+++ b/pyrates/frontend/template/circuit.py
@@ -939,7 +939,7 @@ class CircuitTemplate(AbstractBaseTemplate):
         net = self.circuits if self.circuits else self.nodes
         net_node = net[node[0]]
         if isinstance(net_node, CircuitTemplate):
-            self.add_node_template(node[1:], template=template)
+            net_node.add_node_template(node[1:], template=template)
         else:
             self.nodes[node[0]] = template
 


### PR DESCRIPTION
Try fixing issue #39

Also a typo in `python_definitions.py`: the `equations` in `pro` uses `V_th`, but `variables` uses `V_thr`