### PR TITLE
Try fixing issue #42

### DIFF
--- a/pyrates/frontend/template/circuit.py
+++ b/pyrates/frontend/template/circuit.py
@@ -1085,7 +1085,6 @@ class CircuitTemplate(AbstractBaseTemplate):
         self._state_var_indices.clear()
         clear_ir_caches()
         input_labels.clear()
-        OperatorTemplate.cache.clear()
         gc.collect()
 
     @property


### PR DESCRIPTION
Added `OperatorTemplate.cache.clear()` to clear global operator cache in `CircuitTemplate.clear()`