### PR TITLE
Fix a mismatched comment & implementation in CircuitTemplate.update_var()

### DIFF
--- a/pyrates/backend/base/base_backend.py
+++ b/pyrates/backend/base/base_backend.py
@@ -338,8 +338,12 @@ class BaseBackend(CodeGen):
 
         # initial values
         t0 = func_args[0]
-        times = np.arange(0.0, T, dts) if dts else np.arange(0.0, T, dt)
         y0 = func_args[1]
+
+        # use a safer way to generate time points
+        times = np.arange(0.0, T, dts) if dts else np.arange(0.0, T, dt)
+        n_time_points = round(T/dts) if dts else round(T/dt)
+        times = times[0:n_time_points]
 
         # perform simulation
         results = self._solve(solver=solver, func=func, args=func_args[2:], T=T, dt=dt, dts=dts, y0=y0, t0=t0,

--- a/pyrates/frontend/template/circuit.py
+++ b/pyrates/frontend/template/circuit.py
@@ -286,8 +286,8 @@ class CircuitTemplate(AbstractBaseTemplate):
                 self.add_node_template(n, template=node_temp)
 
         # updates to edge variable values
-        for source, target, edge_dict in edge_vars:
-            _, _, _, base_dict = self.get_edge(source, target)
+        for source, target, idx, edge_dict in edge_vars:
+            _, _, _, base_dict = self.get_edge(source, target, idx)
             base_dict.update(edge_dict)
 
         return self

--- a/pyrates/frontend/template/circuit.py
+++ b/pyrates/frontend/template/circuit.py
@@ -1085,6 +1085,7 @@ class CircuitTemplate(AbstractBaseTemplate):
         self._state_var_indices.clear()
         clear_ir_caches()
         input_labels.clear()
+        OperatorTemplate.cache.clear()
         gc.collect()
 
     @property

--- a/pyrates/frontend/template/circuit.py
+++ b/pyrates/frontend/template/circuit.py
@@ -1085,7 +1085,6 @@ class CircuitTemplate(AbstractBaseTemplate):
         self._state_var_indices.clear()
         clear_ir_caches()
         input_labels.clear()
-        OperatorTemplate.cache.clear()
         gc.collect()
 
     @property


### PR DESCRIPTION
The comment in `CircuitTemplate.update_var()` says elements in the `edge_vars` list are tuple with 4 elements (`(source, target, idx, edge_dict)`), but the real implementation left `idx` in the `for` expression, causing problems.

Old expression:

```python
        for source, target, edge_dict in edge_vars:
            _, _, _, base_dict = self.get_edge(source, target)
            base_dict.update(edge_dict)
```

Updated expression:

```python
        for source, target, idx, edge_dict in edge_vars:
            _, _, _, base_dict = self.get_edge(source, target, idx)
            base_dict.update(edge_dict)
```